### PR TITLE
firmware: fix I2C pins and clock for XIAO ESP32C6

### DIFF
--- a/firmware/ESP32C6_AS5601/ESP32C6_AS5601.ino
+++ b/firmware/ESP32C6_AS5601/ESP32C6_AS5601.ino
@@ -2,18 +2,16 @@
 #include <Wire.h>
 #include "AS5601.h"
 
-static constexpr uint32_t I2C_CLOCK_HZ = 400000;
+static constexpr uint32_t I2C_CLOCK_HZ = 100000;
 // Side + 3-digit index: "L###" for the left gripper, "R###" for the right,
 // e.g. "L003" / "R003".
-static const char* DEVICE_ID = "CHANGE HERE";
+static const char* DEVICE_ID = "R003";
 
 
 AS5601 encoder(Wire, 0x36, false);
 
 void setup()
 {
-	Wire.begin();
-  Wire.setClock(400000);
 	Serial.begin(115200);
 	while (!Serial)
 	{
@@ -21,8 +19,8 @@ void setup()
 	}
 
 #if defined(ESP32) || defined(ARDUINO_ARCH_ESP32)
-	constexpr int SDA_PIN = 21;
-	constexpr int SCL_PIN = 22;
+	constexpr int SDA_PIN = 20;
+	constexpr int SCL_PIN = 19;
 	encoder.begin(I2C_CLOCK_HZ, SDA_PIN, SCL_PIN);
 #else
 	encoder.begin(I2C_CLOCK_HZ);

--- a/firmware/ESP32C6_AS5601/ESP32C6_AS5601.ino
+++ b/firmware/ESP32C6_AS5601/ESP32C6_AS5601.ino
@@ -5,7 +5,7 @@
 static constexpr uint32_t I2C_CLOCK_HZ = 100000;
 // Side + 3-digit index: "L###" for the left gripper, "R###" for the right,
 // e.g. "L003" / "R003".
-static const char* DEVICE_ID = "R003";
+static const char* DEVICE_ID = "CHANGE HERE";
 
 
 AS5601 encoder(Wire, 0x36, false);


### PR DESCRIPTION
## Description
Bug fixes for the AS5601 encoder firmware targeting the Seeed XIAO ESP32C6.

- Lower I2C clock from 400kHz to 100kHz for stable AS5601 operation
- Fix SDA/SCL pin assignment from 21/22 to 20/19 to match the XIAO ESP32C6 pinout
- Remove duplicate `Wire.begin()` / `Wire.setClock()` in `setup()` — `encoder.begin()` handles this internally

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Flashed onto a Seeed XIAO ESP32C6 + AS5601 and verified encoder values stream correctly via Serial monitor.